### PR TITLE
SQL - Update CreateDatabases.sql

### DIFF
--- a/Files/sql/CreateDatabases.sql
+++ b/Files/sql/CreateDatabases.sql
@@ -1,7 +1,7 @@
 /*
  * File: CreateDatabases.sql
  * Author(s): Matthew Dobson
- * Date modified: 2018-11-6
+ * Date modified: 11-9-2018
  *
  * Description: A SQL script to setup the MariaDB SQL databases.
  *

--- a/Files/sql/CreateDatabases.sql
+++ b/Files/sql/CreateDatabases.sql
@@ -32,14 +32,13 @@ CREATE TABLE UsersDB.Users(
 CREATE DATABASE PasswordsDB;
 
 /*
- * A table which associates the salted and hashed password of each user and the
- * corresponding user's ID with a password ID.
+ * A table which associates the salted and hashed password of each user with the
+ * corresponding user's ID.
  */
 CREATE TABLE PasswordsDB.Passwords(
-    ID                      INT          UNSIGNED NOT NULL,
     userID                  INT          UNSIGNED NOT NULL,
     saltedAndHashedPassword VARCHAR(256)          NOT NULL,
-    PRIMARY KEY (ID),
+    PRIMARY KEY (userID),
     FOREIGN KEY (userID) REFERENCES UsersDB.Users(ID)
 );
 


### PR DESCRIPTION
Remove the ID field from the Passwords table and use userID as its primary key. Otherwise a user could have multiple passwords with no way to tell which is current.