### PR TITLE
PHP - Adjust returned 2D array inner array type

### DIFF
--- a/Files/php/AuthenticationConnection.php
+++ b/Files/php/AuthenticationConnection.php
@@ -3,7 +3,7 @@
 /*
  * File: AuthenticationConnection.php
  * Author(s): Matthew Dobson
- * Date modified: 11-15-2018
+ * Date modified: 11-21-2018
  *
  * Description: Defines a concrete PHP class extending abstract class
  * DatabaseConnection to represent, manipulate and transmit a connection to the
@@ -83,6 +83,6 @@ class AuthenticationConnection extends DatabaseConnection {
         }
 
         // Return the salted and hashed password.
-        return $getPasswordResult[0][0];
+        return $getPasswordResult[0]['saltedAndHashedPassword'];
     }
 }

--- a/Files/php/DatabaseConnection.php
+++ b/Files/php/DatabaseConnection.php
@@ -3,7 +3,7 @@
 /*
  * File: DatabaseConnection.php
  * Author(s): Matthew Dobson
- * Date modified: 11-15-2018
+ * Date modified: 11-21-2018
  * Description: Defines an abstract PHP class to represent, manipulate and
  * transmit a connection to the bookkeeper application's MariaDB SQL database.
  * Concrete classes extending this class will handle connections to the database
@@ -87,7 +87,7 @@ abstract class DatabaseConnection {
      *
      * @return the userID, or FALSE if no user exists with username $username.
      */
-    protected function getUserID(string $username) {
+    public function getUserID(string $username) {
         // Query UsersDB.Users to get the ID associated with $username.
         $getUserIDResult =
             $this->runQuery(
@@ -117,7 +117,7 @@ abstract class DatabaseConnection {
         }
 
         // Return just the userID.
-        return $getUserIDResult[0][0];
+        return $getUserIDResult[0]['ID'];
     }
 
     /**
@@ -130,9 +130,9 @@ abstract class DatabaseConnection {
      * for a string, "b" for a blob).
      * @param ...$parameters the parameters.
      *
-     * @return an array of arrays containing the result of the query; FALSE if
-     * a non-SELECT statement was issued or a SELECT statement was issued and
-     * the result could not be obtained.
+     * @return an array of associative arrays containing the result of the
+     * query; FALSE if a non-SELECT statement was issued or a SELECT statement
+     * was issued and the result could not be obtained.
      */
     protected function runQuery(
         string $SQLStatement,
@@ -176,7 +176,7 @@ abstract class DatabaseConnection {
             // statement or if any other type of statement is used; only extract
             // an array of arrays from the result if it is not FALSE.
             if($result) {
-                $resultArrayOrFalse = $result->fetch_all();
+                $resultArrayOrFalse = $result->fetch_all(MYSQLI_ASSOC);
             }
         } finally {
             // Make sure the statement and result are closed and freed.

--- a/Files/php/PasswordsConnection.php
+++ b/Files/php/PasswordsConnection.php
@@ -3,7 +3,7 @@
 /*
  * File: PasswordsConnection.php
  * Author(s): Matthew Dobson
- * Date modified: 11-15-2018
+ * Date modified: 11-21-2018
  *
  * Description: Defines a concrete PHP class extending abstract class
  * DatabaseConnection to represent, manipulate and transmit a connection to the
@@ -115,7 +115,9 @@ class PasswordsConnection extends DatabaseConnection {
         }
 
         // If the queried password does not equal what it should, return 0.
-        if($getUpdatedPasswordResult[0][0] != $saltedAndHashedPassword) {
+        if(
+            $getUpdatedPasswordResult[0]['saltedAndHashedPassword'] !=
+                $saltedAndHashedPassword) {
             return 0;
         }
 


### PR DESCRIPTION
Modified DatabaseConnection::runQuery(string,string,...mixed) so that it returns a numeric array of associative arrays rather than a numeric array of numeric arrays; DatabaseConnection::getUserID(string), AuthenticationConnection::getSaltedAndHashedPassword(string) and PasswordsConnection::setUserPassword(string,string) also modified slightly to handle the change.
DatabaseConnection::getUserID(string) changed from protected to public.