### PR TITLE
PHP/CSS - Multiple CSS file concatenator/minifier

### DIFF
--- a/Files/css/styles.css
+++ b/Files/css/styles.css
@@ -4,9 +4,6 @@
  * Author     : Andrew Eissen
  */
 
-@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,300,700");
-@import url("https://fonts.googleapis.com/css?family=Montserrat");
-
 :root {
   --bpg-gold: #e9d787;
   --bpg-offwhite: #f6f6f6;

--- a/Files/index.html
+++ b/Files/index.html
@@ -10,7 +10,11 @@ Author: Andrew Eissen
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>CMSC 495 Bookkeeping Project</title>
-    <link rel="stylesheet" type="text/css" href="css/styles.css">
+    <link rel="stylesheet" type="text/css"
+      href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,700">
+    <link rel="stylesheet" type="text/css"
+      href="https://fonts.googleapis.com/css?family=Montserrat">
+    <link rel="stylesheet" type="text/css" href="php/styles.php">
     <script type="text/javascript" src="js/app.js"></script>
   </head>
   <body onload="BookkeepingProjectModule.init()"></body>

--- a/Files/php/styles.php
+++ b/Files/php/styles.php
@@ -1,0 +1,81 @@
+<?php
+
+  /**
+   * This function is the primary concatenation and minification handler of the
+   * PHP file in question, used to remove all unneeded comments, comment
+   * symbols, and assorted indentation and whitespace characters as needed. Once
+   * the styles have been minified and cleaned up, their contents are bolted on
+   * to any previously minified contents to ensure that only one request for CSS
+   * styles is made on page load rather than several depending on the number of
+   * individual files present in the CSS directory folder. This will allow the
+   * CSS engineers and specialists to divide CSS into encapsulating files as
+   * needed without having to add a separate import to the HTML file each time.
+   *
+   * @author Andrew Eissen
+   * @param buffer $outputBuffer The output buffer object
+   * @return buffer $outputBuffer The modified output buffer object
+   */
+  function minifyStyles ($outputBuffer) {
+
+    // Regex denoting text and comment symbols in styles
+    $commentsRegex = '!/\*[^*]*\*+([^/][^*]*\*+)*/!';
+
+    // Array of various spacing/indentation characters to remove
+    $noncodeCharacters = array("\t", "\r", "\n", "\r\n", '  ', '    ');
+
+    // Remove comments from styles
+    $outputBuffer = preg_replace($commentsRegex, '', $outputBuffer);
+
+    /* Remove tabs, spaces, and newlines */
+    $outputBuffer = str_replace($noncodeCharacters, '', $outputBuffer);
+
+    // Return modified buffer
+    return $outputBuffer;
+  }
+
+  /**
+   * This function is used to begin the concatenation/minification process. It
+   * first marks the request as a <code>text/css</code> type via the appropriate
+   * header, initializes a new output buffer object, then runs through the
+   * argument parameter directory looking for wellformed files. Each of these is
+   * included and handled by the parameter buffer handler function, which picks
+   * over its style content and removes comments and assorted indentation and
+   * spacing characters while concatenating its contents to any previous styles.
+   * <br />
+   * <br />
+   * This function set is used simply to limit the number of HTTP requests for
+   * CSS files required upon the loading of the DOM and the rendering of the
+   * page. Additionally, the removal of comments and whitespace reduces the need
+   * for an external minifier and associated <code>styles.min.css</code> build.
+   *
+   * @author Andrew Eissen
+   * @param string $paramDirectory String representation of CSS directory
+   * @param string $paramBaseFile String representation of base CSS file
+   * @param string $paramHandler String representation of buffer handler
+   * @return void
+   */
+  function init ($paramDirectory, $paramBaseFile, $paramHandler) {
+
+    // Denote HTTP request header type
+    header('Content-type: text/css');
+
+    // Initialize output buffer
+    ob_start($paramHandler);
+
+    // Start with root/base file (may contain @imports and :root)
+    include($paramDirectory . '/' . $paramBaseFile);
+
+    // Iterate through directory and include remaining wellformed files
+    foreach (new DirectoryIterator($paramDirectory) as $file) {
+      if ($file->isFile() && $file->getFilename() !== $paramBaseFile) {
+        include($file->getPathname());
+      }
+    }
+
+    // Discard output buffer contents
+    ob_end_flush();
+  }
+
+  // Begin the concatenation process
+  init('../css', 'styles.css', 'minifyStyles');
+?>


### PR DESCRIPTION
This update handles a few issues that will make life easier for the CSS engineers:
* The `@import` statements previously in `styles.css` have been removed to `index.html`. This will prevent render blocking and allow all styles to be loaded concurrently without each having to wait on the completion of the others.
* The addition of a CSS concatenation and minification file will allow the CSS specialists to create multiple CSS files as needed without having to add an import to the `index.html` file for each. This will allow for the saving of bandwidth as only one HTTP request for CSS styling will be made for all of the encapsulating CSS files in the directory.
* Additionally, this PHP file also minifies the file contents, removing whitespace and comments prior to inclusion on the page, thus speeding up rendering and loading times accordingly.