### PR TITLE
JavaScript/CSS - Account creation module + updates

### DIFF
--- a/Files/css/styles.css
+++ b/Files/css/styles.css
@@ -180,16 +180,16 @@
      text-align: center;
 
 }
- #login-main-header {
+ #login-body-header {
      text-align: center;
 
      font-size: large;
 }
- #login-main-input-holder {
+ #login-body-input-holder {
      text-align: center;
      margin: 15px 15px 15px;
 }
- .login-main-input-textbox {
+ .login-body-input-textbox {
      width: 90%;
      margin: 10px 10px;
      padding: 10px;

--- a/Files/js/app.js
+++ b/Files/js/app.js
@@ -2448,7 +2448,9 @@ const BookkeepingProjectModule = (function () {
   };
 
   /**
-   * @description
+   * @description This presently noop'ed function will be used to toggle between
+   * the documents overview table and the general ledger table on the press of
+   * the appropriate sidebar button.
    *
    * @returns {void}
    */


### PR DESCRIPTION
This update changes some things around to allow for a cleaner, less duplicate-heavy approach to scene building.
* Refactor of `tinderize` and `fade` to allow for optional swiping right and to permit partial, in-scene fading in and out. This allows for partial loading of scenes without having to rebuild the entire page.
* Addition of first draft account creation module. Using updates above, the login module frame (including header) is retained on the page, with only the inner body of the module removed and replaced with textfields and buttons related to the registration of a new account.
* Addition of dashboard view switching button that when pressed will make use of newly refactored `tinderize` to fade out of the presently viewed HTML table and replace it with another table. Example: If user is viewing the general ledger table and presses the button, the ledger will be replaced with the document overview table.
* Rename of some identifiers and addition of new `ModuleButtons` enum to remove need for in-function button config objects.