### PR TITLE
CSS - Media width correction

### DIFF
--- a/Files/css/media.css
+++ b/Files/css/media.css
@@ -113,7 +113,7 @@
         border-bottom: 1px solid var(--bpg-lightgray, #eeeeee);
         position: relative;
         padding-left: 40%;
-        width: 100% !important;
+        width: 60% !important;
     }
 
     td .general-link-button {


### PR DESCRIPTION
Final correction for the `@media` column width - when I set it to 100% for the table change, I failed to consider the 40% padding necessary to add the headers in on the converted column which was causing the text-wrapping not to work.  This is the final CSS correction I'm aware of. 